### PR TITLE
fix: re-link examples in dialog overview to changed story names

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -69,9 +69,9 @@
 #storybook-explorer-tree a.sidebar-item:hover, .light a.sidebar-item:focus {
     background-color: hsla(0,0%,100%,.04);
 }
-.sidebar-item#example-dialog--anatomy,
-.sidebar-item#example-dialog--logout,
-.sidebar-item#example-dialog--udf {
+.sidebar-item#components-dialog--anatomy,
+.sidebar-item#components-dialog--logout,
+.sidebar-item#components-dialog--udf {
     display: none;
 }
 .sidebar-item + a[class*="ButtonLink"] {

--- a/lib/components/dialog/dialog-overview.stories.mdx
+++ b/lib/components/dialog/dialog-overview.stories.mdx
@@ -17,9 +17,9 @@ import { Dialog } from '@storybook/components';
 />
 
 <style>{`
-  #story--example-dialog--anatomy > div,
-  #story--example-dialog--logout > div,
-  #story--example-dialog--udf > div {
+  #story--components-dialog--anatomy > div,
+  #story--components-dialog--logout > div,
+  #story--components-dialog--udf > div {
     height: 20rem !important;
   }
   .preview-dark {
@@ -39,19 +39,23 @@ import { Dialog } from '@storybook/components';
 
 - Use only when the user has to make a decision RIGHT NOW
 - It's always better to do the action and then allow an "undo" option rather than using an "Are you sure?" dialog
-- To notify the user less intrusively, consider using a [snackbar](?path=/story/example-snackbar--basic) instead
+- To notify the user less intrusively, consider using a [snackbar](?path=/story/components-snackbar--basic) instead
 
 ***
 
 ## Anatomy
 
-<Story id="example-dialog--basic" parameters={{ docs: { disable: true }, darkMode: {current: 'dark', stylePreview: true} }} ></Story>
+<Pre>
+  <Story id="components-dialog--anatomy" />
+</Pre>
 
-## Examples
+***
+
+## Components
 
 <Pre>
-  <Story id="example-dialog--logout" />
+  <Story id="components-dialog--logout" />
 </Pre>
 <Pre>
-  <Story id="example-dialog--udf" />
+  <Story id="components-dialog--udf" />
 </Pre>


### PR DESCRIPTION
Missed a spot when renaming components. This gets the examples on the Dialogs overview page working again, and hides the demo stories in question from the nav.