### PR TITLE
fix: update representing state guide

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: 16
           cache: npm
-      - run: npm ci
+      - run: npm ci --legacy-peer-deps
         # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@v1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Installing
 
-`npm ci`
+`npm ci` (if running npm 6 or earlier)
+`npm ci --legacy-peer-deps` (if running npm 7 or later)
 
 ## Running Storybook
 

--- a/lib/components/src/icon/_icon.scss
+++ b/lib/components/src/icon/_icon.scss
@@ -1,0 +1,5 @@
+@mixin core-styles() {
+    .covalent-icon {
+        --mdc-icon-font: 'covalent-icons';
+    }
+}

--- a/lib/components/styles/styles.scss
+++ b/lib/components/styles/styles.scss
@@ -1,14 +1,10 @@
+@use "../src/icon/icon" as icon;
 @use "../src/list/list" as list;
 @use "../src/skeleton/skeleton.styles" as skeleton;
 
+@include icon.core-styles();
 @include list.core-styles();
 @include skeleton.core-styles();
-
-// Icon 
-// TODO move to its own imports
-.covalent-icon {
-    --mdc-icon-font: 'covalent-icons';
-}
 
 // TODO move to its own toolbar imports
 .td-toolbar {

--- a/lib/icons/covalent-icons.css
+++ b/lib/icons/covalent-icons.css
@@ -1,10 +1,10 @@
 @font-face {
   font-family: 'covalent-icons';
-  src:  url('fonts/covalent-icons.eot?x0fu5w');
-  src:  url('fonts/covalent-icons.eot?x0fu5w#iefix') format('embedded-opentype'),
-    url('fonts/covalent-icons.ttf?x0fu5w') format('truetype'),
-    url('fonts/covalent-icons.woff?x0fu5w') format('woff'),
-    url('fonts/covalent-icons.svg?x0fu5w#covalent-icons') format('svg');
+  src:  url('./covalent-icons.eot?x0fu5w');
+  src:  url('./covalent-icons.eot?x0fu5w#iefix') format('embedded-opentype'),
+    url('./covalent-icons.ttf?x0fu5w') format('truetype'),
+    url('./covalent-icons.woff?x0fu5w') format('woff'),
+    url('./covalent-icons.svg?x0fu5w#covalent-icons') format('svg');
   font-weight: normal;
   font-style: normal;
   font-display: block;

--- a/lib/icons/svgs/state_changed.svg
+++ b/lib/icons/svgs/state_changed.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill="#000000" d="M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"/>
+</svg>

--- a/stories/guide-representing-state.stories.mdx
+++ b/stories/guide-representing-state.stories.mdx
@@ -45,16 +45,16 @@ For giving opinionated feedback. Error messages, loading, status indicators, etc
 
 ## State types
 
-| Use case | Icon | Icon handle | Icon set | Color | Color |
-| -------- | ---- | ----------- | -------- | ----- | ----- |
-| Cancelled | <td-icon>not_interested</td-icon> | not_interested | Material | Icon disabled | <td-icon>pause</td-icon> |
-| Caution / warning | <td-icon class="caution">warning</td-icon> | warning | Material | Foreground caution | <td-icon>pause</td-icon> |
-| Changed | <td-icon class="covalent-icon">state_changed</td-icon> | state_changed | Covalent | Foreground primary | <td-icon>pause</td-icon> |
-| Error | <td-icon class="negative">error</td-icon> | error | Material | Foreground negative | <td-icon>pause</td-icon> |
-| Paused | <td-icon>pause</td-icon> | pause | Material | Icon | <td-icon>pause</td-icon> |
-| Pending / waiting | <td-icon>loader_dots</td-icon> | loader_dots | Covalent | Icon | <td-icon>pause</td-icon> |
-| Running | <td-icon>loader_dots</td-icon> | Use loading spinner | Material | Foreground accent | <td-icon>pause</td-icon> |
-| Success | <td-icon class="positive">check</td-icon> | check | Material | Foreground positive | <td-icon>pause</td-icon> |
+| Use case | Icon | Icon handle | Icon set | Color |
+| -------- | ---- | ----------- | -------- | ----- |
+| Cancelled | <td-icon>not_interested</td-icon> | not_interested | Material | Icon disabled |
+| Caution / warning | <td-icon class="caution">warning</td-icon> | warning | Material | Foreground caution |
+| Changed | <td-icon class="covalent-icon">state_changed</td-icon> | state_changed | Covalent | Foreground primary |
+| Error | <td-icon class="negative">error</td-icon> | error | Material | Foreground negative |
+| Paused | <td-icon>pause</td-icon> | pause | Material | Icon |
+| Pending / waiting | <td-icon class="covalent-icon">loader_dots</td-icon> | loader_dots | Covalent | Icon |
+| Running | <td-circular-progress indeterminate density="-6"></td-circular-progress> | circular progress | Covalent | Icon |
+| Success | <td-icon class="positive">check</td-icon> | check | Material | Foreground positive |
 
 ***
 


### PR DESCRIPTION
* Moved icon styling out of styles.scss and into its own scss file. It's now imported like other global styles in styles.scss.
* Updated path of the font files, which made covalent icons work again locally. :)

_Please note_: the `state_changed` icon is not yet part of the font files and won't show up still.

**Before**
![Screen Shot 2022-07-07 at 11 12 40 AM](https://user-images.githubusercontent.com/16616355/178026585-9d6f8707-6c11-4982-be22-d7e11e3e98ae.png)

**Af
![Screen Shot 2022-07-07 at 11 12 02 AM](https://user-images.githubusercontent.com/16616355/178026608-0967e07f-4fa7-4edd-976c-5b1e17fe545d.png)
ter**
