### PR TITLE
Feat/cc 5/tree list

### DIFF
--- a/lib/components/src/tree-list/tree-list-item.scss
+++ b/lib/components/src/tree-list/tree-list-item.scss
@@ -1,20 +1,44 @@
-.container {
-    display: flex;
-    flex-direction: column;
-}
 .itemContent {
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+    width: fit-content;
     margin-top: 8px;
+    padding: 2px 32px 2px 8px;
 }
 .itemContent:hover {
     cursor: pointer;
+    background-color: var(--mdc-theme-surface-primary-highlight-hover);
+    color: var(--mdc-theme-primary);
+    border-radius: 0 20px 20px 0;
 }
-.iconContainer {
+.mainContent {
     display: flex;
+    flex-direction: row;
+}
+td-icon {
+    opacity: 0.6;
+}
+[name="label"]::slotted(*) {
+    font-family: var(--mdc-typography-body1-font-family);
+    font-size: var(--mdc-typography-body1-font-size);
+    font-weight: var(--mdc-typography-body1-font-weight);
+    line-height: var(--mdc-typography-body1-line-height);
+    opacity: 0.87;
+    letter-spacing: 0.25px;
+    padding-left: 16px;
+}
+[name="extraContent"]::slotted(*) {
+    padding-left: 64px;
+    opacity: 0.6;
+    letter-spacing: 0.4px;
+    font-family: var(--mdc-typography-caption-font-family);
+    font-size: var(--mdc-typography-caption-font-size);
+    font-weight: var(--mdc-typography-caption-font-weight);
+    line-height: var(--mdc-typography-caption-line-height);
 }
 [name="nest"]::slotted(*) {
-    margin-left: 16px;
+    padding-left: 16px;
 }
 .hidden {
     display: none;
@@ -24,7 +48,22 @@
     flex-direction: column;
 }
 .endOfNest {
-    margin-left: 32px;
+    padding-left: 38px;
     margin-top: 8px;
+    opacity: 0.38;
+    letter-spacing: 0.4px;
     user-select: none;
+    font-family: var(--mdc-typography-caption-font-family);
+    font-size: var(--mdc-typography-caption-font-size);
+    font-weight: var(--mdc-typography-caption-font-weight);
+    line-height: var(--mdc-typography-caption-line-height);
+}
+
+.open {
+    transition: transform 100ms ease-out;
+    transform: rotate(90deg);
+}
+.close {
+    transition: transform 100ms ease-in;
+    transform: rotate(0deg);
 }

--- a/lib/components/src/tree-list/tree-list-item.scss
+++ b/lib/components/src/tree-list/tree-list-item.scss
@@ -12,7 +12,7 @@
 .itemContent {
   // .itemContent is a div so its width will be the width of its parent.
   padding: 0px 32px 0px var(--indent);
-  // margin-right: 16px;
+  margin-right: 16px;
 }
 .itemContent:hover {
   cursor: pointer;

--- a/lib/components/src/tree-list/tree-list-item.scss
+++ b/lib/components/src/tree-list/tree-list-item.scss
@@ -9,8 +9,15 @@
 .itemContent:hover {
     cursor: pointer;
     background-color: var(--mdc-theme-surface-neutral-highlight-hover);
-    // color: var(--mdc-theme-primary);
     border-radius: 0 16px 16px 0;
+}
+.selected {
+    background-color: var(--mdc-theme-surface-primary-highlight);    
+    color: var(--mdc-theme-primary);
+    border-radius: 0 16px 16px 0;
+}
+.selected:hover {
+    background-color: var(--mdc-theme-surface-primary-highlight-hover);
 }
 .mainContent {
     display: flex;
@@ -59,6 +66,10 @@ td-icon {
     line-height: var(--mdc-typography-caption-line-height);
 }
 
+// Arrow icon should always be this color.
+.arrowIcon {
+    color: var(--mdc-theme-text-primary-on-background);
+}
 .open {
     transition: transform 100ms ease-out;
     transform: rotate(90deg);

--- a/lib/components/src/tree-list/tree-list-item.scss
+++ b/lib/components/src/tree-list/tree-list-item.scss
@@ -23,29 +23,25 @@
     display: flex;
     flex-direction: row;
 }
-td-icon {
-    opacity: 0.6;
-}
 [name="label"]::slotted(*) {
     font-family: var(--mdc-typography-body1-font-family);
     font-size: var(--mdc-typography-body1-font-size);
     font-weight: var(--mdc-typography-body1-font-weight);
     line-height: var(--mdc-typography-body1-line-height);
-    opacity: 0.87;
     letter-spacing: 0.25px;
     padding-left: 16px;
 }
 [name="extraContent"]::slotted(*) {
     padding-left: 64px;
-    opacity: 0.6;
     letter-spacing: 0.4px;
+    color: var(--mdc-theme-text-secondary-on-background);
     font-family: var(--mdc-typography-caption-font-family);
     font-size: var(--mdc-typography-caption-font-size);
     font-weight: var(--mdc-typography-caption-font-weight);
     line-height: var(--mdc-typography-caption-line-height);
 }
 [name="nest"]::slotted(*) {
-    margin-left: 16px;
+    padding-left: 16px;
 }
 .hidden {
     display: none;
@@ -57,9 +53,9 @@ td-icon {
 .endOfNest {
     padding-left: 38px;
     margin-top: 8px;
-    opacity: 0.38;
     letter-spacing: 0.4px;
     user-select: none;
+    color: var(--mdc-theme-text-secondary-on-background);
     font-family: var(--mdc-typography-caption-font-family);
     font-size: var(--mdc-typography-caption-font-size);
     font-weight: var(--mdc-typography-caption-font-weight);

--- a/lib/components/src/tree-list/tree-list-item.scss
+++ b/lib/components/src/tree-list/tree-list-item.scss
@@ -12,16 +12,8 @@
 .itemContent {
   // .itemContent is a div so its width will be the width of its parent.
   padding: 0px 32px 0px var(--indent);
-  margin-right: 16px;
+  // margin-right: 16px;
 }
-// Attempting to add a hoverable region to the blankspace.
-// .itemContent::after {
-//   content: "";
-//   width: 16px;
-//   position: absolute;
-//   inset: 0 0 0 100%;
-//   border-radius: 0;
-// }
 .itemContent:hover {
   cursor: pointer;
   background-color: var(--mdc-theme-surface-neutral-highlight-hover);
@@ -69,7 +61,7 @@
 }
 .endOfNest {
   padding: 8px;
-  padding-left: calc(var(--indent) + 28px);
+  padding-left: calc(var(--indent) + 20px);
   letter-spacing: 0.4px;
   user-select: none;
   color: var(--mdc-theme-text-disabled-on-background);
@@ -78,7 +70,6 @@
   font-weight: var(--mdc-typography-caption-font-weight);
   line-height: var(--mdc-typography-caption-line-height);
 }
-// Arrow icon should always be this color.
 .arrowIcon {
   color: var(--mdc-theme-text-primary-on-background);
 }

--- a/lib/components/src/tree-list/tree-list-item.scss
+++ b/lib/components/src/tree-list/tree-list-item.scss
@@ -1,6 +1,5 @@
 .itemContent {
-    display: flex;
-    flex-direction: column;
+    // .itemContent is a div so its width will be the width of its parent.
     padding: 0px 32px 0px var(--indent);
 }
 .itemContent:hover {

--- a/lib/components/src/tree-list/tree-list-item.scss
+++ b/lib/components/src/tree-list/tree-list-item.scss
@@ -8,8 +8,8 @@
 }
 .itemContent:hover {
     cursor: pointer;
-    background-color: var(--mdc-theme-surface-primary-highlight-hover);
-    color: var(--mdc-theme-primary);
+    background-color: var(--mdc-theme-surface-neutral-highlight-hover);
+    // color: var(--mdc-theme-primary);
     border-radius: 0 16px 16px 0;
 }
 .mainContent {

--- a/lib/components/src/tree-list/tree-list-item.scss
+++ b/lib/components/src/tree-list/tree-list-item.scss
@@ -2,15 +2,15 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    width: fit-content;
-    margin-top: 8px;
+    width: 100%;
+    margin-top: 6px;
     padding: 2px 32px 2px 8px;
 }
 .itemContent:hover {
     cursor: pointer;
     background-color: var(--mdc-theme-surface-primary-highlight-hover);
     color: var(--mdc-theme-primary);
-    border-radius: 0 20px 20px 0;
+    border-radius: 0 16px 16px 0;
 }
 .mainContent {
     display: flex;
@@ -38,7 +38,7 @@ td-icon {
     line-height: var(--mdc-typography-caption-line-height);
 }
 [name="nest"]::slotted(*) {
-    padding-left: 16px;
+    margin-left: 16px;
 }
 .hidden {
     display: none;

--- a/lib/components/src/tree-list/tree-list-item.scss
+++ b/lib/components/src/tree-list/tree-list-item.scss
@@ -1,10 +1,7 @@
 .itemContent {
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    width: 100%;
-    margin-top: 6px;
-    padding: 2px 32px 2px 8px;
+    padding: 0px 32px 0px var(--indent);
 }
 .itemContent:hover {
     cursor: pointer;
@@ -22,6 +19,7 @@
 .mainContent {
     display: flex;
     flex-direction: row;
+    padding: 4px 0px;
 }
 [name="label"]::slotted(*) {
     font-family: var(--mdc-typography-body1-font-family);
@@ -40,9 +38,6 @@
     font-weight: var(--mdc-typography-caption-font-weight);
     line-height: var(--mdc-typography-caption-line-height);
 }
-[name="nest"]::slotted(*) {
-    padding-left: 16px;
-}
 .hidden {
     display: none;
 }
@@ -51,17 +46,16 @@
     flex-direction: column;
 }
 .endOfNest {
-    padding-left: 38px;
-    margin-top: 8px;
+    padding: 8px;
+    padding-left: calc(var(--indent) + 28px);
     letter-spacing: 0.4px;
     user-select: none;
-    color: var(--mdc-theme-text-secondary-on-background);
+    color: var(--mdc-theme-text-disabled-on-background);
     font-family: var(--mdc-typography-caption-font-family);
     font-size: var(--mdc-typography-caption-font-size);
     font-weight: var(--mdc-typography-caption-font-weight);
     line-height: var(--mdc-typography-caption-line-height);
 }
-
 // Arrow icon should always be this color.
 .arrowIcon {
     color: var(--mdc-theme-text-primary-on-background);

--- a/lib/components/src/tree-list/tree-list-item.scss
+++ b/lib/components/src/tree-list/tree-list-item.scss
@@ -1,69 +1,92 @@
-.itemContent {
-    // .itemContent is a div so its width will be the width of its parent.
-    padding: 0px 32px 0px var(--indent);
+@use "@material/ripple";
+
+.mdc-ripple-surface {
+  @include ripple.surface;
+  @include ripple.radius-bounded(50%);
+  @include ripple.states;
 }
+.mdc-ripple-surface::after,
+.mdc-ripple-surface::before {
+  border-radius: 0 16px 16px 0;
+}
+.itemContent {
+  // .itemContent is a div so its width will be the width of its parent.
+  padding: 0px 32px 0px var(--indent);
+  margin-right: 16px;
+}
+// Attempting to add a hoverable region to the blankspace.
+// .itemContent::after {
+//   content: "";
+//   width: 16px;
+//   position: absolute;
+//   inset: 0 0 0 100%;
+//   border-radius: 0;
+// }
 .itemContent:hover {
-    cursor: pointer;
-    background-color: var(--mdc-theme-surface-neutral-highlight-hover);
-    border-radius: 0 16px 16px 0;
+  cursor: pointer;
+  background-color: var(--mdc-theme-surface-neutral-highlight-hover);
+  border-radius: 0 16px 16px 0;
 }
 .selected {
-    background-color: var(--mdc-theme-surface-primary-highlight);    
-    color: var(--mdc-theme-primary);
-    border-radius: 0 16px 16px 0;
+  background-color: var(--mdc-theme-surface-primary-highlight);
+  color: var(--mdc-theme-primary);
+  border-radius: 0 16px 16px 0;
 }
+
 .selected:hover {
-    background-color: var(--mdc-theme-surface-primary-highlight-hover);
+  background-color: var(--mdc-theme-surface-primary-highlight-hover);
 }
 .mainContent {
-    display: flex;
-    flex-direction: row;
-    padding: 4px 0px;
+  display: flex;
+  flex-direction: row;
+  padding: 4px 0px;
 }
 [name="label"]::slotted(*) {
-    font-family: var(--mdc-typography-body1-font-family);
-    font-size: var(--mdc-typography-body1-font-size);
-    font-weight: var(--mdc-typography-body1-font-weight);
-    line-height: var(--mdc-typography-body1-line-height);
-    letter-spacing: 0.25px;
-    padding-left: 16px;
+  font-family: var(--mdc-typography-body1-font-family);
+  font-size: var(--mdc-typography-body1-font-size);
+  font-weight: var(--mdc-typography-body1-font-weight);
+  line-height: var(--mdc-typography-body1-line-height);
+  letter-spacing: 0.25px;
+  padding-left: 16px;
 }
 [name="extraContent"]::slotted(*) {
-    padding-left: 64px;
-    letter-spacing: 0.4px;
-    color: var(--mdc-theme-text-secondary-on-background);
-    font-family: var(--mdc-typography-caption-font-family);
-    font-size: var(--mdc-typography-caption-font-size);
-    font-weight: var(--mdc-typography-caption-font-weight);
-    line-height: var(--mdc-typography-caption-line-height);
+  padding-left: 64px;
+  padding-bottom: 4px;
+  margin-top: -4px;
+  letter-spacing: 0.4px;
+  color: var(--mdc-theme-text-secondary-on-background);
+  font-family: var(--mdc-typography-caption-font-family);
+  font-size: var(--mdc-typography-caption-font-size);
+  font-weight: var(--mdc-typography-caption-font-weight);
+  line-height: var(--mdc-typography-caption-line-height);
 }
 .hidden {
-    display: none;
+  display: none;
 }
 .visible {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 .endOfNest {
-    padding: 8px;
-    padding-left: calc(var(--indent) + 28px);
-    letter-spacing: 0.4px;
-    user-select: none;
-    color: var(--mdc-theme-text-disabled-on-background);
-    font-family: var(--mdc-typography-caption-font-family);
-    font-size: var(--mdc-typography-caption-font-size);
-    font-weight: var(--mdc-typography-caption-font-weight);
-    line-height: var(--mdc-typography-caption-line-height);
+  padding: 8px;
+  padding-left: calc(var(--indent) + 28px);
+  letter-spacing: 0.4px;
+  user-select: none;
+  color: var(--mdc-theme-text-disabled-on-background);
+  font-family: var(--mdc-typography-caption-font-family);
+  font-size: var(--mdc-typography-caption-font-size);
+  font-weight: var(--mdc-typography-caption-font-weight);
+  line-height: var(--mdc-typography-caption-line-height);
 }
 // Arrow icon should always be this color.
 .arrowIcon {
-    color: var(--mdc-theme-text-primary-on-background);
+  color: var(--mdc-theme-text-primary-on-background);
 }
 .open {
-    transition: transform 100ms ease-out;
-    transform: rotate(90deg);
+  transition: transform 100ms ease-out;
+  transform: rotate(90deg);
 }
 .close {
-    transition: transform 100ms ease-in;
-    transform: rotate(0deg);
+  transition: transform 100ms ease-in;
+  transform: rotate(0deg);
 }

--- a/lib/components/src/tree-list/tree-list-item.scss
+++ b/lib/components/src/tree-list/tree-list-item.scss
@@ -1,0 +1,30 @@
+.container {
+    display: flex;
+    flex-direction: column;
+}
+.itemContent {
+    display: flex;
+    align-items: center;
+    margin-top: 8px;
+}
+.itemContent:hover {
+    cursor: pointer;
+}
+.iconContainer {
+    display: flex;
+}
+[name="nest"]::slotted(*) {
+    margin-left: 16px;
+}
+.hidden {
+    display: none;
+}
+.visible {
+    display: flex;
+    flex-direction: column;
+}
+.endOfNest {
+    margin-left: 32px;
+    margin-top: 8px;
+    user-select: none;
+}

--- a/lib/components/src/tree-list/tree-list-item.ts
+++ b/lib/components/src/tree-list/tree-list-item.ts
@@ -1,6 +1,6 @@
 import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
-import { classMap } from "lit/directives/class-map";
+import { customElement, property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 import styles from './tree-list-item.scss';
 
 declare global {

--- a/lib/components/src/tree-list/tree-list-item.ts
+++ b/lib/components/src/tree-list/tree-list-item.ts
@@ -22,7 +22,7 @@ class CovalentTreeListItem extends LitElement {
             'hidden': !this.isOpen,
             'visible': this.isOpen,
         };
-        // Classes that animate the arrows.
+        // Class map for animating the arrows.
         const animation = {
             'open': this.isOpen,
             'close': !this.isOpen
@@ -47,14 +47,16 @@ class CovalentTreeListItem extends LitElement {
             </slot>
         `
     }
-    // Toggles the dropdown for a list item.
     private _handleClick() {
+        // Toggles the dropdown for a list item.
         this.isOpen = !this.isOpen;
+        
         // Create and emit the select event; the tree-list component is listening for this.
         let event = new CustomEvent('select', {
             detail: {
                 message: `Emitting an event from ${this}`,
             },
+            // bubbles and composed are required in order to allow custom event to pass through shadow DOM boundary to td-tree-list.
             bubbles: true,
             composed: true,
         });

--- a/lib/components/src/tree-list/tree-list-item.ts
+++ b/lib/components/src/tree-list/tree-list-item.ts
@@ -37,7 +37,7 @@ class CovalentTreeListItem extends LitElement {
 
         // The nest slot should only take td-tree-list-item components. Otherwise use default value and display "No results".
         return html`
-            <div class="itemContent" @click="${this._handleClick}" style="--indent:${this.indentLevel*this.indentMultiple+this.indentMultiple}px">
+            <div class="itemContent mdc-ripple-surface" @click="${this._handleClick}" style="--indent:${this.indentLevel*this.indentMultiple+8}px">
                 <div class="mainContent">
                     ${arrow}
                     ${icon}

--- a/lib/components/src/tree-list/tree-list-item.ts
+++ b/lib/components/src/tree-list/tree-list-item.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from "lit";
-import { customElement, state } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import styles from './tree-list-item.scss';
 
@@ -12,34 +12,42 @@ declare global {
 @customElement('td-tree-list-item')
 class CovalentTreeListItem extends LitElement {
     static override styles = [styles];
-    // Internal state to check if an item is open.
-    @state() isOpen = false;
-    
+    // Check if a list item is open.
+    @property({type: Boolean}) isOpen = false;
+    // Optional icon for each list item.
+    @property({type: String}) icon = '';
     override render() {
-        const arrowIcon = this.isOpen ? 'arrow_drop_down' : 'arrow_right';
-        const arrow =  html`<td-icon>${arrowIcon}</td-icon>`;
-        const icon = html`<td-icon>description</td-icon>`;
+        // Class map for showing/hiding an item's content.
         const classes = {
             'hidden': !this.isOpen,
             'visible': this.isOpen,
         };
-        // The nest slot should only take td-tree-list-item components. Otherwise display "No results".
+        // Classes that animate the arrows.
+        const animation = {
+            'open': this.isOpen,
+            'close': !this.isOpen
+        };
+        const arrowIcon = 'arrow_right';
+        const icon = html`<td-icon>${this.icon}</td-icon>`;
+        const arrow =  html`<td-icon class="${classMap(animation)}">${arrowIcon}</td-icon>`;
+        // The nest slot should only take td-tree-list-item components. Otherwise use default value and display "No results".
         return html`
-            <div class="container">
-                <div class="itemContent" @click="${this._handleClick}">
+            <div class="itemContent" @click="${this._handleClick}">
+                <div class="mainContent">
                     ${arrow}
                     ${icon}
-                    <slot name="content"></slot>
+                    <slot name="label"></slot>
                 </div>
-                <slot name="nest" class="${classMap(classes)}">
-                    <div class="endOfNest">
-                        No results
-                    </div>
-                </slot>
+                <slot name="extraContent"></slot>
             </div>
+            <slot name="nest" class="${classMap(classes)}">
+                <div class="endOfNest ${classMap(classes)}">
+                    No results
+                </div>
+            </slot>
         `
     }
-
+    // Toggles the dropdown for a list item.
     private _handleClick() {
         this.isOpen = !this.isOpen;
     }

--- a/lib/components/src/tree-list/tree-list-item.ts
+++ b/lib/components/src/tree-list/tree-list-item.ts
@@ -1,0 +1,46 @@
+import { html, LitElement } from "lit";
+import { customElement, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+import styles from './tree-list-item.scss';
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'td-tree-list-item': CovalentTreeListItem,
+    }
+}
+
+@customElement('td-tree-list-item')
+class CovalentTreeListItem extends LitElement {
+    static override styles = [styles];
+    // Internal state to check if an item is open.
+    @state() isOpen = false;
+    
+    override render() {
+        const arrowIcon = this.isOpen ? 'arrow_drop_down' : 'arrow_right';
+        const arrow =  html`<td-icon>${arrowIcon}</td-icon>`;
+        const icon = html`<td-icon>description</td-icon>`;
+        const classes = {
+            'hidden': !this.isOpen,
+            'visible': this.isOpen,
+        };
+        // The nest slot should only take td-tree-list-item components. Otherwise display "No results".
+        return html`
+            <div class="container">
+                <div class="itemContent" @click="${this._handleClick}">
+                    ${arrow}
+                    ${icon}
+                    <slot name="content"></slot>
+                </div>
+                <slot name="nest" class="${classMap(classes)}">
+                    <div class="endOfNest">
+                        No results
+                    </div>
+                </slot>
+            </div>
+        `
+    }
+
+    private _handleClick() {
+        this.isOpen = !this.isOpen;
+    }
+}

--- a/lib/components/src/tree-list/tree-list-item.ts
+++ b/lib/components/src/tree-list/tree-list-item.ts
@@ -16,6 +16,10 @@ class CovalentTreeListItem extends LitElement {
     @property({type: Boolean}) isOpen = false;
     // Optional icon for each list item.
     @property({type: String}) icon = '';
+    // Indicates which nest level a list item is at.
+    @property({type: Number}) indentLevel = 0;
+    // How much left padding (px) to add for nested elements.
+    @property({type: Number}) indentMultiple = 16;
     override render() {
         // Class map for showing/hiding an item's content.
         const classes = {
@@ -30,9 +34,10 @@ class CovalentTreeListItem extends LitElement {
         const arrowIcon = 'arrow_right';
         const icon = html`<td-icon>${this.icon}</td-icon>`;
         const arrow =  html`<td-icon class="${classMap(animation)} arrowIcon">${arrowIcon}</td-icon>`;
+
         // The nest slot should only take td-tree-list-item components. Otherwise use default value and display "No results".
         return html`
-            <div class="itemContent" @click="${this._handleClick}">
+            <div class="itemContent" @click="${this._handleClick}" style="--indent:${this.indentLevel*this.indentMultiple+this.indentMultiple}px">
                 <div class="mainContent">
                     ${arrow}
                     ${icon}
@@ -40,8 +45,9 @@ class CovalentTreeListItem extends LitElement {
                 </div>
                 <slot name="extraContent"></slot>
             </div>
+            
             <slot name="nest" class="${classMap(classes)}">
-                <div class="endOfNest ${classMap(classes)}">
+                <div class="endOfNest" style="--indent:${this.indentLevel*this.indentMultiple+this.indentMultiple}px">
                     No results
                 </div>
             </slot>

--- a/lib/components/src/tree-list/tree-list-item.ts
+++ b/lib/components/src/tree-list/tree-list-item.ts
@@ -45,7 +45,6 @@ class CovalentTreeListItem extends LitElement {
                 </div>
                 <slot name="extraContent"></slot>
             </div>
-            
             <slot name="nest" class="${classMap(classes)}">
                 <div class="endOfNest" style="--indent:${this.indentLevel*this.indentMultiple+this.indentMultiple}px">
                     No results

--- a/lib/components/src/tree-list/tree-list-item.ts
+++ b/lib/components/src/tree-list/tree-list-item.ts
@@ -29,7 +29,7 @@ class CovalentTreeListItem extends LitElement {
         };
         const arrowIcon = 'arrow_right';
         const icon = html`<td-icon>${this.icon}</td-icon>`;
-        const arrow =  html`<td-icon class="${classMap(animation)}">${arrowIcon}</td-icon>`;
+        const arrow =  html`<td-icon class="${classMap(animation)} arrowIcon">${arrowIcon}</td-icon>`;
         // The nest slot should only take td-tree-list-item components. Otherwise use default value and display "No results".
         return html`
             <div class="itemContent" @click="${this._handleClick}">
@@ -50,5 +50,14 @@ class CovalentTreeListItem extends LitElement {
     // Toggles the dropdown for a list item.
     private _handleClick() {
         this.isOpen = !this.isOpen;
+        // Create and emit the select event; the tree-list component is listening for this.
+        let event = new CustomEvent('select', {
+            detail: {
+                message: `Emitting an event from ${this}`,
+            },
+            bubbles: true,
+            composed: true,
+        });
+        this.dispatchEvent(event);
     }
 }

--- a/lib/components/src/tree-list/tree-list.scss
+++ b/lib/components/src/tree-list/tree-list.scss
@@ -1,12 +1,12 @@
 @use '@material/typography/mdc-typography';
 
 .container {
-    overflow-x: auto;
+  overflow-x: auto;
 }
 .content {
-    color: var(--mdc-theme-text-primary-on-background);
-    // Inline-block width is based on children.
-    display: inline-block;
-    // Set the min-width to 100% so the menu items always extend edge to edge.
-    min-width: 100%;
+  color: var(--mdc-theme-text-primary-on-background);
+  // Inline-block width is based on children.
+  display: inline-block;
+  // Set the min-width to 100% so the menu items always extend edge to edge.
+  min-width: 100%;
 }

--- a/lib/components/src/tree-list/tree-list.scss
+++ b/lib/components/src/tree-list/tree-list.scss
@@ -1,7 +1,7 @@
 @use '@material/typography/mdc-typography';
 
 .container {
-    color: black;
+    color: var(--mdc-theme-text-primary-on-background);
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/lib/components/src/tree-list/tree-list.scss
+++ b/lib/components/src/tree-list/tree-list.scss
@@ -1,8 +1,12 @@
 @use '@material/typography/mdc-typography';
 
 .container {
+    overflow-x: auto;
+}
+.content {
     color: var(--mdc-theme-text-primary-on-background);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
+    // Inline-block width is based on children.
+    display: inline-block;
+    // Set the min-width to 100% so the menu items always extend edge to edge.
+    min-width: 100%;
 }

--- a/lib/components/src/tree-list/tree-list.scss
+++ b/lib/components/src/tree-list/tree-list.scss
@@ -1,6 +1,8 @@
 @use '@material/typography/mdc-typography';
 
 .container {
+    color: black;
     display: flex;
+    flex-direction: column;
     justify-content: center;
 }

--- a/lib/components/src/tree-list/tree-list.scss
+++ b/lib/components/src/tree-list/tree-list.scss
@@ -1,0 +1,6 @@
+@use '@material/typography/mdc-typography';
+
+.container {
+    display: flex;
+    justify-content: center;
+}

--- a/lib/components/src/tree-list/tree-list.stories.js
+++ b/lib/components/src/tree-list/tree-list.stories.js
@@ -1,0 +1,33 @@
+import './tree-list';
+import './tree-list-item';
+export default {
+    title: 'Components/Tree List',
+    parameters: {
+        layout: 'centered',
+    }
+}
+
+export const TreeList = ({}) => {
+    return `
+        <td-tree-list>
+            <td-tree-list-item>
+                <div slot="content">1</div>
+                <td-tree-list-item slot="nest">
+                    <div slot="content">1a</div>
+                    <td-tree-list-item slot="nest">
+                        <div slot="content">1b</div>
+                        <td-tree-list-item slot="nest">
+                            <div slot="content">1bi</div>
+                        </td-tree-list-item>
+                    </td-tree-list-item>
+                    <td-tree-list-item slot="nest">
+                        <div slot="content">1c</div>
+                    </td-tree-list-item>
+                    <td-tree-list-item slot="nest">
+                        <div slot="content">1d</div>
+                    </td-tree-list-item>
+                </td-tree-list-item>
+            </td-tree-list-item>
+        </td-tree-list>
+    `
+}

--- a/lib/components/src/tree-list/tree-list.stories.js
+++ b/lib/components/src/tree-list/tree-list.stories.js
@@ -2,31 +2,125 @@ import './tree-list';
 import './tree-list-item';
 export default {
     title: 'Components/Tree List',
+    argTypes: {
+        icon: {
+            control: 'text',
+            defaultValue: 'description'
+        }
+    },
     parameters: {
         layout: 'centered',
     }
 }
 
-export const TreeList = ({}) => {
+export const TreeList = ({icon}) => {
     return `
         <td-tree-list>
-            <td-tree-list-item>
-                <div slot="content">1</div>
-                <td-tree-list-item slot="nest">
-                    <div slot="content">1a</div>
-                    <td-tree-list-item slot="nest">
-                        <div slot="content">1b</div>
-                        <td-tree-list-item slot="nest">
-                            <div slot="content">1bi</div>
-                        </td-tree-list-item>
+            <td-tree-list-item icon="${icon}">
+                <div slot="label">PDCRAdmin</div>
+            </td-tree-list-item>
+        </td-tree-list>
+        <td-tree-list>
+            <td-tree-list-item icon="${icon}" isOpen="true">
+                <div slot="label">PDCRAdmin</div>
+                <td-tree-list-item icon="${icon}" slot="nest">
+                    <div slot="label">PDCRAdmin</div>
+                </td-tree-list-item>
+                <td-tree-list-item icon="${icon}" slot="nest" isOpen="true">
+                    <div slot="label">PDCRAdmin</div>
+                    <td-tree-list-item icon="${icon}" slot="nest">
+                        <div slot="label">PDCRAdmin</div>
                     </td-tree-list-item>
-                    <td-tree-list-item slot="nest">
-                        <div slot="content">1c</div>
-                    </td-tree-list-item>
-                    <td-tree-list-item slot="nest">
-                        <div slot="content">1d</div>
+                    <td-tree-list-item icon="${icon}" slot="nest">
+                        <div slot="label">PDCRAdmin</div>
                     </td-tree-list-item>
                 </td-tree-list-item>
+            </td-tree-list-item>
+        </td-tree-list>
+        <td-tree-list>
+            <td-tree-list-item icon="${icon}">
+                <div slot="label">PDCRAdmin</div>
+            </td-tree-list-item>
+        </td-tree-list>
+        <td-tree-list>
+            <td-tree-list-item icon="${icon}">
+                <div slot="label">PDCRAdmin</div>
+            </td-tree-list-item>
+        </td-tree-list>
+    `
+}
+
+export const TwoLineItems = ({icon}) => {
+    return `
+        <td-tree-list>
+            <td-tree-list-item icon="${icon}">
+                <div slot="label">PDCRAdmin</div>
+            </td-tree-list-item>
+        </td-tree-list>
+        <td-tree-list>
+            <td-tree-list-item icon="${icon}" isOpen="true">
+                <div slot="label">PDCRAdmin</div>
+                <td-tree-list-item icon="${icon}" slot="nest">
+                    <div slot="label">PDCRAdmin</div>
+                </td-tree-list-item>
+                <td-tree-list-item icon="${icon}" slot="nest" isOpen="true">
+                    <div slot="label">PDCRAdmin</div>
+                    <td-tree-list-item icon="${icon}" slot="nest">
+                        <div slot="label">PDCRAdmin</div>
+                        <div slot="extraContent">VARCHAR(8)</div>
+                    </td-tree-list-item>
+                    <td-tree-list-item icon="${icon}" slot="nest">
+                        <div slot="label">PDCRAdmin</div>
+                        <div slot="extraContent">VARCHAR(8)</div>
+                    </td-tree-list-item>
+                </td-tree-list-item>
+            </td-tree-list-item>
+        </td-tree-list>
+        <td-tree-list>
+            <td-tree-list-item icon="${icon}">
+                <div slot="label">PDCRAdmin</div>
+            </td-tree-list-item>
+        </td-tree-list>
+        <td-tree-list>
+            <td-tree-list-item icon="${icon}">
+                <div slot="label">PDCRAdmin</div>
+            </td-tree-list-item>
+        </td-tree-list>
+    `
+}
+
+export const EmptyState = ({icon}) => {
+    return `
+        <td-tree-list>
+            <td-tree-list-item icon="${icon}">
+                <div slot="label">PDCRAdmin</div>
+            </td-tree-list-item>
+        </td-tree-list>
+        <td-tree-list>
+            <td-tree-list-item icon="${icon}" isOpen="true">
+                <div slot="label">PDCRAdmin</div>
+                <td-tree-list-item icon="${icon}" slot="nest">
+                    <div slot="label">PDCRAdmin</div>
+                </td-tree-list-item>
+                <td-tree-list-item icon="${icon}" slot="nest" isOpen="true">
+                    <div slot="label">PDCRAdmin</div>
+                    <td-tree-list-item icon="${icon}" slot="nest" isOpen="true">
+                        <div slot="label">PDCRAdmin</div>
+                    </td-tree-list-item>
+                    <td-tree-list-item icon="${icon}" slot="nest">
+                        <div slot="label">PDCRAdmin</div>
+                    </td-tree-list-item>
+                </td-tree-list-item>
+            </td-tree-list-item>
+        </td-tree-list>
+        <td-tree-list>
+            <td-tree-list-item icon="${icon}">
+                <div slot="label">PDCRAdmin</div>
+            </td-tree-list-item>
+        </td-tree-list>
+        <td-tree-list>
+            <td-tree-list-item icon="${icon}">
+                <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
         </td-tree-list>
     `

--- a/lib/components/src/tree-list/tree-list.stories.js
+++ b/lib/components/src/tree-list/tree-list.stories.js
@@ -1,20 +1,20 @@
-import './tree-list';
-import './tree-list-item';
+import "./tree-list";
+import "./tree-list-item";
 export default {
-    title: 'Components/Tree List',
-    argTypes: {
-        icon: {
-            control: 'text',
-            defaultValue: 'description'
-        }
+  title: "Components/Tree List",
+  argTypes: {
+    icon: {
+      control: "text",
+      defaultValue: "description",
     },
-    parameters: {
-        layout: 'centered',
-    }
-}
+  },
+  parameters: {
+    layout: "centered",
+  },
+};
 
-export const TreeList = ({icon}) => {
-    return `
+export const TreeList = ({ icon }) => {
+  return `
         <td-tree-list>
             <td-tree-list-item icon="${icon}">
                 <div slot="label">PDCRAdmin</div>
@@ -47,11 +47,11 @@ export const TreeList = ({icon}) => {
                 <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
         </td-tree-list>
-    `
-}
+    `;
+};
 
-export const TwoLineItems = ({icon}) => {
-    return `
+export const TwoLineItems = ({ icon }) => {
+  return `
         <td-tree-list>
             <td-tree-list-item icon="${icon}">
                 <div slot="label">PDCRAdmin</div>
@@ -80,11 +80,11 @@ export const TwoLineItems = ({icon}) => {
                 <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
         </td-tree-list>
-    `
-}
+    `;
+};
 
-export const EmptyState = ({icon}) => {
-    return `
+export const EmptyState = ({ icon }) => {
+  return `
         <td-tree-list>
             <td-tree-list-item icon="${icon}">
                 <div slot="label">PDCRAdmin</div>
@@ -111,11 +111,11 @@ export const EmptyState = ({icon}) => {
                 <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
         </td-tree-list>
-    `
-}
+    `;
+};
 // Putting the tree list into a container that has a set width.
-export const OverflowTest = ({icon}) => {
-    return `
+export const OverflowTest = ({ icon }) => {
+  return `
         <div style="width: 300px; border-left: solid white 1px; border-right: solid white 1px">
             <td-tree-list>
                 <td-tree-list-item icon="${icon}">
@@ -150,5 +150,5 @@ export const OverflowTest = ({icon}) => {
                 </td-tree-list-item>
             </td-tree-list>
         </div>
-    `
-}
+    `;
+};

--- a/lib/components/src/tree-list/tree-list.stories.js
+++ b/lib/components/src/tree-list/tree-list.stories.js
@@ -19,8 +19,6 @@ export const TreeList = ({icon}) => {
             <td-tree-list-item icon="${icon}">
                 <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
-        </td-tree-list>
-        <td-tree-list>
             <td-tree-list-item icon="${icon}" isOpen="true">
                 <div slot="label">PDCRAdmin</div>
                 <td-tree-list-item icon="${icon}" slot="nest" indentLevel="1">
@@ -42,13 +40,9 @@ export const TreeList = ({icon}) => {
                     </td-tree-list-item>
                 </td-tree-list-item>
             </td-tree-list-item>
-        </td-tree-list>
-        <td-tree-list>
             <td-tree-list-item icon="${icon}">
                 <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
-        </td-tree-list>
-        <td-tree-list>
             <td-tree-list-item icon="${icon}">
                 <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
@@ -62,8 +56,6 @@ export const TwoLineItems = ({icon}) => {
             <td-tree-list-item icon="${icon}">
                 <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
-        </td-tree-list>
-        <td-tree-list>
             <td-tree-list-item icon="${icon}" isOpen="true">
                 <div slot="label">PDCRAdmin</div>
                 <td-tree-list-item icon="${icon}" slot="nest" indentLevel="1">
@@ -81,13 +73,9 @@ export const TwoLineItems = ({icon}) => {
                     </td-tree-list-item>
                 </td-tree-list-item>
             </td-tree-list-item>
-        </td-tree-list>
-        <td-tree-list>
             <td-tree-list-item icon="${icon}">
                 <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
-        </td-tree-list>
-        <td-tree-list>
             <td-tree-list-item icon="${icon}">
                 <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
@@ -101,8 +89,6 @@ export const EmptyState = ({icon}) => {
             <td-tree-list-item icon="${icon}">
                 <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
-        </td-tree-list>
-        <td-tree-list>
             <td-tree-list-item icon="${icon}" isOpen="true">
                 <div slot="label">PDCRAdmin</div>
                 <td-tree-list-item icon="${icon}" slot="nest" indentLevel="1">
@@ -118,16 +104,51 @@ export const EmptyState = ({icon}) => {
                     </td-tree-list-item>
                 </td-tree-list-item>
             </td-tree-list-item>
-        </td-tree-list>
-        <td-tree-list>
+            <td-tree-list-item icon="${icon}">
+                <div slot="label">PDCRAdmin</div>
+            </td-tree-list-item>
             <td-tree-list-item icon="${icon}">
                 <div slot="label">PDCRAdmin</div>
             </td-tree-list-item>
         </td-tree-list>
-        <td-tree-list>
-            <td-tree-list-item icon="${icon}">
-                <div slot="label">PDCRAdmin</div>
-            </td-tree-list-item>
-        </td-tree-list>
+    `
+}
+// Putting the tree list into a container that has a set width.
+export const OverflowTest = ({icon}) => {
+    return `
+        <div style="width: 300px; border-left: solid white 1px; border-right: solid white 1px">
+            <td-tree-list>
+                <td-tree-list-item icon="${icon}">
+                    <div slot="label">PDCRAdmin</div>
+                </td-tree-list-item>
+                <td-tree-list-item icon="${icon}" isOpen="true">
+                    <div slot="label">PDCRAdmin</div>
+                    <td-tree-list-item icon="${icon}" slot="nest" indentLevel="1">
+                        <div slot="label">PDCRAdmin</div>
+                    </td-tree-list-item>
+                    <td-tree-list-item icon="${icon}" slot="nest" isOpen="true" indentLevel="1">
+                        <div slot="label">PDCRAdmin</div>
+                        <td-tree-list-item icon="${icon}" slot="nest" indentLevel="2">
+                            <div slot="label">PDCRAdmin</div>
+                        </td-tree-list-item>
+                        <td-tree-list-item icon="${icon}" slot="nest" isOpen="true" indentLevel="2">
+                            <div slot="label">PDCRAdmin</div>
+                            <td-tree-list-item icon="${icon}" slot="nest" isOpen="true" indentLevel="3">
+                                <div slot="label">PDCRAdmin</div>
+                                <td-tree-list-item icon="${icon}" slot="nest" isOpen="true" indentLevel="4">
+                                    <div slot="label">AReallyLongLabelAReallyLongLabelAReallyLongLabelAReallyLongLabelAReallyLongLabelAReallyLongLabelAReallyLongLabel</div>
+                                </td-tree-list-item>
+                            </td-tree-list-item>
+                        </td-tree-list-item>
+                    </td-tree-list-item>
+                </td-tree-list-item>
+                <td-tree-list-item icon="${icon}">
+                    <div slot="label">PDCRAdmin</div>
+                </td-tree-list-item>
+                <td-tree-list-item icon="${icon}">
+                    <div slot="label">PDCRAdmin</div>
+                </td-tree-list-item>
+            </td-tree-list>
+        </div>
     `
 }

--- a/lib/components/src/tree-list/tree-list.stories.js
+++ b/lib/components/src/tree-list/tree-list.stories.js
@@ -121,7 +121,7 @@ export const OverflowTest = ({ icon }) => {
                 <td-tree-list-item icon="${icon}">
                     <div slot="label">PDCRAdmin</div>
                 </td-tree-list-item>
-                <td-tree-list-item icon="${icon}" isOpen="true">
+                <td-tree-list-item icon="${icon}">
                     <div slot="label">PDCRAdmin</div>
                     <td-tree-list-item icon="${icon}" slot="nest" indentLevel="1">
                         <div slot="label">PDCRAdmin</div>

--- a/lib/components/src/tree-list/tree-list.stories.js
+++ b/lib/components/src/tree-list/tree-list.stories.js
@@ -23,16 +23,22 @@ export const TreeList = ({icon}) => {
         <td-tree-list>
             <td-tree-list-item icon="${icon}" isOpen="true">
                 <div slot="label">PDCRAdmin</div>
-                <td-tree-list-item icon="${icon}" slot="nest">
+                <td-tree-list-item icon="${icon}" slot="nest" indentLevel="1">
                     <div slot="label">PDCRAdmin</div>
                 </td-tree-list-item>
-                <td-tree-list-item icon="${icon}" slot="nest" isOpen="true">
+                <td-tree-list-item icon="${icon}" slot="nest" isOpen="true" indentLevel="1">
                     <div slot="label">PDCRAdmin</div>
-                    <td-tree-list-item icon="${icon}" slot="nest">
+                    <td-tree-list-item icon="${icon}" slot="nest" indentLevel="2">
                         <div slot="label">PDCRAdmin</div>
                     </td-tree-list-item>
-                    <td-tree-list-item icon="${icon}" slot="nest">
+                    <td-tree-list-item icon="${icon}" slot="nest" indentLevel="2">
                         <div slot="label">PDCRAdmin</div>
+                        <td-tree-list-item icon="${icon}" slot="nest" indentLevel="3">
+                            <div slot="label">PDCRAdmin</div>
+                            <td-tree-list-item icon="${icon}" slot="nest" indentLevel="4">
+                                <div slot="label">PDCRAdmin</div>
+                            </td-tree-list-item>
+                        </td-tree-list-item>
                     </td-tree-list-item>
                 </td-tree-list-item>
             </td-tree-list-item>
@@ -60,16 +66,16 @@ export const TwoLineItems = ({icon}) => {
         <td-tree-list>
             <td-tree-list-item icon="${icon}" isOpen="true">
                 <div slot="label">PDCRAdmin</div>
-                <td-tree-list-item icon="${icon}" slot="nest">
+                <td-tree-list-item icon="${icon}" slot="nest" indentLevel="1">
                     <div slot="label">PDCRAdmin</div>
                 </td-tree-list-item>
-                <td-tree-list-item icon="${icon}" slot="nest" isOpen="true">
+                <td-tree-list-item icon="${icon}" slot="nest" isOpen="true" indentLevel="1">
                     <div slot="label">PDCRAdmin</div>
-                    <td-tree-list-item icon="${icon}" slot="nest">
+                    <td-tree-list-item icon="${icon}" slot="nest" indentLevel="2">
                         <div slot="label">PDCRAdmin</div>
                         <div slot="extraContent">VARCHAR(8)</div>
                     </td-tree-list-item>
-                    <td-tree-list-item icon="${icon}" slot="nest">
+                    <td-tree-list-item icon="${icon}" slot="nest" indentLevel="2">
                         <div slot="label">PDCRAdmin</div>
                         <div slot="extraContent">VARCHAR(8)</div>
                     </td-tree-list-item>
@@ -99,15 +105,15 @@ export const EmptyState = ({icon}) => {
         <td-tree-list>
             <td-tree-list-item icon="${icon}" isOpen="true">
                 <div slot="label">PDCRAdmin</div>
-                <td-tree-list-item icon="${icon}" slot="nest">
+                <td-tree-list-item icon="${icon}" slot="nest" indentLevel="1">
                     <div slot="label">PDCRAdmin</div>
                 </td-tree-list-item>
-                <td-tree-list-item icon="${icon}" slot="nest" isOpen="true">
+                <td-tree-list-item icon="${icon}" slot="nest" isOpen="true" indentLevel="1">
                     <div slot="label">PDCRAdmin</div>
-                    <td-tree-list-item icon="${icon}" slot="nest" isOpen="true">
+                    <td-tree-list-item icon="${icon}" slot="nest" isOpen="true" indentLevel="2">
                         <div slot="label">PDCRAdmin</div>
                     </td-tree-list-item>
-                    <td-tree-list-item icon="${icon}" slot="nest">
+                    <td-tree-list-item icon="${icon}" slot="nest" indentLevel="2">
                         <div slot="label">PDCRAdmin</div>
                     </td-tree-list-item>
                 </td-tree-list-item>

--- a/lib/components/src/tree-list/tree-list.ts
+++ b/lib/components/src/tree-list/tree-list.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement } from "lit/decorators";
 import styles from './tree-list.scss';
 
 declare global {
@@ -11,8 +11,6 @@ declare global {
 @customElement('td-tree-list')
 class CovalentTreeList extends LitElement {
     static override styles = [styles];
-    @property({type: Boolean}) nested = false;
-    @state() isOpen = false;
     override render() {
         return html`
         <div class="container">

--- a/lib/components/src/tree-list/tree-list.ts
+++ b/lib/components/src/tree-list/tree-list.ts
@@ -19,3 +19,21 @@ class CovalentTreeList extends LitElement {
         `
     }
 }
+// Create event listener for td-tree-list-item's select event
+document.addEventListener('select', (e: Event) => {handleSelect(e)});
+const handleSelect = (e: Event): void => {
+    // All td-tree-list-item components.
+    const items = Array.from(document.querySelectorAll('td-tree-list-item'));
+    
+    // Currently selected item.
+    const target = e.target as HTMLElement;
+    const current = target.shadowRoot!.querySelector('div.itemContent');
+    
+    // Find previously selected element and remove the styling.
+    items.forEach(item => {
+        item.shadowRoot!.querySelector('div.itemContent')?.classList.remove('selected');
+    })
+
+    // Add the selected styling to the currently selected class
+    current!.classList.add('selected');
+}

--- a/lib/components/src/tree-list/tree-list.ts
+++ b/lib/components/src/tree-list/tree-list.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from "lit";
-import { customElement } from "lit/decorators";
+import { customElement } from "lit/decorators.js";
 import styles from './tree-list.scss';
 
 declare global {

--- a/lib/components/src/tree-list/tree-list.ts
+++ b/lib/components/src/tree-list/tree-list.ts
@@ -1,0 +1,23 @@
+import { html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import styles from './tree-list.scss';
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'td-tree-list': CovalentTreeList,
+    }
+}
+// Wraps td-tree-list-item components
+@customElement('td-tree-list')
+class CovalentTreeList extends LitElement {
+    static override styles = [styles];
+    @property({type: Boolean}) nested = false;
+    @state() isOpen = false;
+    override render() {
+        return html`
+        <div class="container">
+            <slot></slot> 
+        </div>
+        `
+    }
+}

--- a/lib/components/src/tree-list/tree-list.ts
+++ b/lib/components/src/tree-list/tree-list.ts
@@ -19,7 +19,7 @@ class CovalentTreeList extends LitElement {
         `
     }
 }
-// Create event listener for td-tree-list-item's select event
+// Create event listener for td-tree-list-item's select event.
 document.addEventListener('select', (e: Event) => {handleSelect(e)});
 const handleSelect = (e: Event): void => {
     // All td-tree-list-item components.
@@ -34,6 +34,6 @@ const handleSelect = (e: Event): void => {
         item.shadowRoot!.querySelector('div.itemContent')?.classList.remove('selected');
     })
 
-    // Add the selected styling to the currently selected class
+    // Add the selected styling to the currently selected item.
     current!.classList.add('selected');
 }

--- a/lib/components/src/tree-list/tree-list.ts
+++ b/lib/components/src/tree-list/tree-list.ts
@@ -14,7 +14,9 @@ class CovalentTreeList extends LitElement {
     override render() {
         return html`
         <div class="container">
-            <slot></slot> 
+            <div class="content">
+                <slot></slot> 
+            </div>
         </div>
         `
     }

--- a/lib/components/src/tree-list/tree-list.ts
+++ b/lib/components/src/tree-list/tree-list.ts
@@ -25,10 +25,10 @@ class CovalentTreeList extends LitElement {
 document.addEventListener('select', (e: Event) => {handleSelect(e)});
 const handleSelect = (e: Event): void => {
     // All td-tree-list-item components.
-    const items = Array.from(document.querySelectorAll('td-tree-list-item'));
+    const items: any[] = Array.from(document.querySelectorAll('td-tree-list-item'));
     
     // Currently selected item.
-    const target = e.target as HTMLElement;
+    const target: HTMLElement = e.target as HTMLElement;
     const current = target.shadowRoot!.querySelector('div.itemContent');
     
     // Find previously selected element and remove the styling.


### PR DESCRIPTION
# Tree List/Menu Component

The last item the user clicked on will be highlighted in light teal. There are also hover states for unselected items (grey) and selected items (darker teal).

`<td-tree-list-item>` can take an `icon` property, which is just a string of the name of the icon the user wants to use. It can also take an `isOpen` property which determines if a list item should be opened or not.

![Screen Shot 2022-07-20 at 1 35 21 PM](https://user-images.githubusercontent.com/47995084/180076690-c8cf6045-3a42-4524-ad81-6a2ebc1ddf1a.png)

Two line items can be achieved by using slots.

<img width="263" alt="Screen Shot 2022-07-20 at 1 38 58 PM" src="https://user-images.githubusercontent.com/47995084/180077268-d2c4526c-cc09-4b63-8426-35cfc4cd2003.png">

If the tree list item has nothing nested within it, the empty state will be displayed via a default slot value.

<img width="230" alt="Screen Shot 2022-07-20 at 1 39 40 PM" src="https://user-images.githubusercontent.com/47995084/180077395-3fc3995b-cbfa-4397-ad49-f8e3c2d994f8.png">


