### PR TITLE
Feat/icon tabs

### DIFF
--- a/lib/components/src/icon-tabs/icon-tab-bar.scss
+++ b/lib/components/src/icon-tabs/icon-tab-bar.scss
@@ -1,3 +1,5 @@
 :host {
   border-bottom: solid 1px var(--mdc-theme-border);
+  padding-left: 16px;
+  padding-right: 16px;
 }

--- a/lib/components/src/icon-tabs/icon-tab-bar.scss
+++ b/lib/components/src/icon-tabs/icon-tab-bar.scss
@@ -1,0 +1,3 @@
+:host {
+  border-bottom: solid 1px var(--mdc-theme-border);
+}

--- a/lib/components/src/icon-tabs/icon-tab-bar.ts
+++ b/lib/components/src/icon-tabs/icon-tab-bar.ts
@@ -1,0 +1,16 @@
+import { html } from 'lit';
+import { TabBarBase } from '@material/mwc-tab-bar/mwc-tab-bar-base';
+import {styles as tabBarStyles} from '@material/mwc-tab-bar/mwc-tab-bar.css';
+import { customElement } from 'lit/decorators.js';
+
+declare global {
+  interface HTMLElementTagNameMap {
+   'td-icon-tab-bar': CovalentIconTabBarBase;
+  }
+}
+
+@customElement('td-icon-tab-bar')
+export class CovalentIconTabBarBase extends TabBarBase {
+  static override styles = [tabBarStyles];
+
+}

--- a/lib/components/src/icon-tabs/icon-tab-bar.ts
+++ b/lib/components/src/icon-tabs/icon-tab-bar.ts
@@ -1,6 +1,6 @@
-import { html } from 'lit';
 import { TabBarBase } from '@material/mwc-tab-bar/mwc-tab-bar-base';
 import {styles as tabBarStyles} from '@material/mwc-tab-bar/mwc-tab-bar.css';
+import styles from "./icon-tab-bar.scss";
 import { customElement } from 'lit/decorators.js';
 
 declare global {
@@ -11,6 +11,5 @@ declare global {
 
 @customElement('td-icon-tab-bar')
 export class CovalentIconTabBarBase extends TabBarBase {
-  static override styles = [tabBarStyles];
-
+  static override styles = [tabBarStyles, styles];
 }

--- a/lib/components/src/icon-tabs/icon-tab.scss
+++ b/lib/components/src/icon-tabs/icon-tab.scss
@@ -1,10 +1,19 @@
 :host {
-  button {
+  width: 200px;
+  height: 160px;
+  button.mdc-tab {
     display: flex;
-    width: 200px;
-    height: 160px;
+    width: 100%;
+    height: 100%;
     align-items: center;
-    padding: 50px;
+    white-space: normal;
+    padding: 0;
+  }
+  span.mdc-tab__content {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
   }
   .mdc-tab:not(.mdc-tab--stacked) .mdc-tab__icon + .mdc-tab__text-label {
     padding: 0;
@@ -15,17 +24,26 @@
     width: 40px;
     height: 40px;
   }
-  span.mdc-tab__content {
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
+  span.mdc-tab__text-label {
+    display: inline-block;
+    overflow-wrap: anywhere;
   }
 }
+:host(:not([active])) {
+  span.mdc-tab__icon {
+    color: var(--mdc-theme-text-disabled-on-background);
+  }
+  span.mdc-tab__text-label {
+    color: var(--mdc-theme-text-secondary-on-background);
+  }
+  .secondLine {
+    color: var(--mdc-theme-text-disabled-on-background);
+  }
+}
+
 :host([active]) {
   .mdc-tab {
     background-color: var(--mdc-theme-surface-primary-highlight);
-    // border-bottom: solid 1px var(--mdc-theme-primary);
   }
   .mdc-tab:hover {
     background-color: var(--mdc-theme-surface-primary-highlight-hover);
@@ -36,12 +54,21 @@
   span.mdc-tab__text-label {
     color: var(--mdc-theme-text-primary-on-background);
   }
+  .secondLine {
+    color: var(--mdc-theme-text-secondary-on-background);
+  }
 }
-:host(:not([active])) {
-  span.mdc-tab__icon {
-    color: var(--mdc-theme-text-disabled-on-background);
-  }
-  span.mdc-tab__text-label {
-    color: var(--mdc-theme-text-primary-on-background);
-  }
+
+.secondLine {
+  letter-spacing: 0.25px;
+  color: var(--mdc-theme-text-disabled-on-background);
+  font-family: var(--mdc-typography-body2-font-family);
+  font-size: var(--mdc-typography-body2-font-size);
+  font-weight: var(--mdc-typography-body2-font-weight);
+  line-height: var(--mdc-typography-body2-line-height);
+  text-transform: lowercase;
+  margin-top: 4px;
+}
+.secondLine::first-letter {
+  text-transform: capitalize;
 }

--- a/lib/components/src/icon-tabs/icon-tab.scss
+++ b/lib/components/src/icon-tabs/icon-tab.scss
@@ -7,7 +7,8 @@
     height: 100%;
     align-items: center;
     white-space: normal;
-    padding: 0;
+    overflow-wrap: anywhere;
+    padding: 16px;
   }
   span.mdc-tab__content {
     flex-direction: column;
@@ -24,9 +25,8 @@
     width: 40px;
     height: 40px;
   }
-  span.mdc-tab__text-label {
-    display: inline-block;
-    overflow-wrap: anywhere;
+  .secondLine {
+    line-height: 16px;
   }
 }
 :host(:not([active])) {

--- a/lib/components/src/icon-tabs/icon-tab.scss
+++ b/lib/components/src/icon-tabs/icon-tab.scss
@@ -66,9 +66,6 @@
   font-size: var(--mdc-typography-body2-font-size);
   font-weight: var(--mdc-typography-body2-font-weight);
   line-height: var(--mdc-typography-body2-line-height);
-  text-transform: lowercase;
+  text-transform: none;
   margin-top: 4px;
-}
-.secondLine::first-letter {
-  text-transform: capitalize;
 }

--- a/lib/components/src/icon-tabs/icon-tab.scss
+++ b/lib/components/src/icon-tabs/icon-tab.scss
@@ -1,0 +1,47 @@
+:host {
+  button {
+    display: flex;
+    width: 200px;
+    height: 160px;
+    align-items: center;
+    padding: 50px;
+  }
+  .mdc-tab:not(.mdc-tab--stacked) .mdc-tab__icon + .mdc-tab__text-label {
+    padding: 0;
+  }
+  span.mdc-tab__icon {
+    margin-bottom: 16px;
+    font-size: 40px;
+    width: 40px;
+    height: 40px;
+  }
+  span.mdc-tab__content {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+}
+:host([active]) {
+  .mdc-tab {
+    background-color: var(--mdc-theme-surface-primary-highlight);
+    // border-bottom: solid 1px var(--mdc-theme-primary);
+  }
+  .mdc-tab:hover {
+    background-color: var(--mdc-theme-surface-primary-highlight-hover);
+  }
+  span.mdc-tab__icon {
+    color: var(--mdc-theme-text-icon-on-background);
+  }
+  span.mdc-tab__text-label {
+    color: var(--mdc-theme-text-primary-on-background);
+  }
+}
+:host(:not([active])) {
+  span.mdc-tab__icon {
+    color: var(--mdc-theme-text-disabled-on-background);
+  }
+  span.mdc-tab__text-label {
+    color: var(--mdc-theme-text-primary-on-background);
+  }
+}

--- a/lib/components/src/icon-tabs/icon-tab.ts
+++ b/lib/components/src/icon-tabs/icon-tab.ts
@@ -1,0 +1,24 @@
+import { customElement, property } from 'lit/decorators.js';
+import { TabBase } from '@material/mwc-tab/mwc-tab-base';
+import {styles as tabBarStyles} from '@material/mwc-tab/mwc-tab.css';
+import styles from "./icon-tab.scss";
+
+declare global {
+  interface HTMLElementTagNameMap {
+   'td-icon-tab': CovalentIconTabBase;
+  }
+}
+
+@customElement('td-icon-tab')
+export class CovalentIconTabBase extends TabBase {
+  static override styles = [styles, tabBarStyles];
+  @property({type: String}) secondLine = '';
+  // Trying to figure out how to append text to a shadow DOM element
+  // override connectedCallback() {
+  //   super.connectedCallback();
+  //   let span = document.createElement('span');
+  //   span.textContent = this.secondLine;
+  //   const button = this.shadowRoot!.querySelector(".mdc-tab")
+  //   console.log(button);
+  // }
+}

--- a/lib/components/src/icon-tabs/icon-tab.ts
+++ b/lib/components/src/icon-tabs/icon-tab.ts
@@ -12,7 +12,7 @@ declare global {
 @customElement('td-icon-tab')
 export class CovalentIconTabBase extends TabBase {
   static override styles = [styles, tabBarStyles];
-  @property({type: String}) secondLine = 'Label';
+  @property({type: String}) secondLine = '';
   
   override firstUpdated() {
     super.firstUpdated();

--- a/lib/components/src/icon-tabs/icon-tab.ts
+++ b/lib/components/src/icon-tabs/icon-tab.ts
@@ -12,13 +12,16 @@ declare global {
 @customElement('td-icon-tab')
 export class CovalentIconTabBase extends TabBase {
   static override styles = [styles, tabBarStyles];
-  @property({type: String}) secondLine = '';
-  // Trying to figure out how to append text to a shadow DOM element
-  // override connectedCallback() {
-  //   super.connectedCallback();
-  //   let span = document.createElement('span');
-  //   span.textContent = this.secondLine;
-  //   const button = this.shadowRoot!.querySelector(".mdc-tab")
-  //   console.log(button);
-  // }
+  @property({type: String}) secondLine = 'Label';
+  
+  override firstUpdated() {
+    super.firstUpdated();
+    let contentContainer = this.shadowRoot!.querySelector('span.mdc-tab__content');
+    
+    let span = document.createElement('div');
+    span.textContent = this.secondLine;
+    span.classList.add('secondLine');
+    
+    contentContainer?.appendChild(span);
+  }
 }

--- a/lib/components/src/icon-tabs/icon-tabs.stories.js
+++ b/lib/components/src/icon-tabs/icon-tabs.stories.js
@@ -1,0 +1,25 @@
+import { withDesign } from "storybook-addon-designs";
+import "./icon-tab-bar";
+import "./icon-tab";
+
+export default {
+  title: "Components/Icon Tabs",
+  argTypes: {},
+  decorators: [withDesign],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/b7geqz0aCeDo4NbzTBWAiw/Empty-states?node-id=19%3A115",
+    },
+  },
+};
+
+export const Template = ({}) => {
+  return `
+        <td-icon-tab-bar>
+            <td-icon-tab label="tabOne" secondLine="Hello" icon="description"></td-icon-tab>
+            <td-icon-tab label="tabOne" secondLine="Some" icon="description"></td-icon-tab>
+            <td-icon-tab label="tabOne" secondLine="Text" icon="description"></td-icon-tab>
+        </td-icon-tab-bar>
+    `;
+};

--- a/lib/components/src/icon-tabs/icon-tabs.stories.js
+++ b/lib/components/src/icon-tabs/icon-tabs.stories.js
@@ -4,22 +4,35 @@ import "./icon-tab";
 
 export default {
   title: "Components/Icon Tabs",
-  argTypes: {},
+  argTypes: {
+    icon: {
+      control: "text",
+      defaultValue: "description",
+    },
+    label: {
+      control: "text",
+      defaultValue: "label",
+    },
+    secondLine: {
+      control: "text",
+      defaultValue: "Secondary text",
+    },
+  },
   decorators: [withDesign],
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/file/b7geqz0aCeDo4NbzTBWAiw/Empty-states?node-id=19%3A115",
+      url: "https://www.figma.com/file/RGYLmkueoutDtl6vQNZTJU/Tabs-with-icons?node-id=1570%3A3664",
     },
   },
 };
 
-export const Template = ({}) => {
+export const Template = ({ icon, label, secondLine }) => {
   return `
         <td-icon-tab-bar>
-            <td-icon-tab label="tabOne" secondLine="Hello" icon="description"></td-icon-tab>
-            <td-icon-tab label="tabOne" secondLine="Some" icon="description"></td-icon-tab>
-            <td-icon-tab label="tabOne" secondLine="Text" icon="description"></td-icon-tab>
+            <td-icon-tab label="${label}" secondLine="${secondLine}" icon="${icon}"></td-icon-tab>
+            <td-icon-tab label="${label}" secondLine="${secondLine}" icon="${icon}"></td-icon-tab>
+            <td-icon-tab label="${label}" secondLine="${secondLine}" icon="${icon}"></td-icon-tab>
         </td-icon-tab-bar>
     `;
 };


### PR DESCRIPTION
# Tabs with icons

- [Figma](https://www.figma.com/file/RGYLmkueoutDtl6vQNZTJU/Tabs-with-icons)
- `td-icon-tab` inherits from TabBase and `td-icon-tab-bar` inherits from TabBarBase.
- Secondary text is optional but icon and label are required (all passed via properties).
- Text and icon darken when selected.

![IconTabDemo](https://user-images.githubusercontent.com/47995084/185259798-e17a4ea5-e354-40d4-9919-80d3fff9016a.gif)

Overflow is accounted for. 

![Screen Shot 2022-08-18 at 9 56 53 AM](https://user-images.githubusercontent.com/47995084/185452101-b7c3656f-0d55-433e-8d3b-5c3073c6ad8e.png)

