### PR TITLE
feat: add writing and naming guide

### DIFF
--- a/.storybook/theme/markdown-elements.scss
+++ b/.storybook/theme/markdown-elements.scss
@@ -79,12 +79,16 @@
     font-weight: var(--mdc-typography-body1-font-weight);
     line-height: var(--mdc-typography-body1-line-height);
 
+    a {
+        color: var(--mdc-theme-secondary);
+        text-decoration: underline;
+    }
+
     .link-list {
         display: grid;
         grid-template-columns: 1fr;
-        grid-template-rows: 1fr 1fr;
+        grid-template-rows: 1fr;
         row-gap: 1.5rem;
-        margin-top: 4rem;
     }
     @media (min-width: 620px) {
         .link-list {
@@ -97,7 +101,7 @@
         .link-list {
             display: -ms-grid;
             -ms-grid-columns: 1fr 1fr;
-            -ms-grid-rows: 1fr 1fr;
+            -ms-grid-rows: 1fr;
         }
     }
 
@@ -110,7 +114,6 @@
         color: var(--mdc-theme-text-secondary-on-background);
         display: flex;
         align-items: flex-start;
-        min-height: 4rem;
         text-decoration: none;
     
         &:hover {
@@ -123,6 +126,28 @@
 
             strong {
                 color: var(--mdc-theme-primary);
+            }
+        }
+        &.link-article {
+            padding-right: 40px;
+            padding-top: 30px;
+            position: relative;
+
+            &::before {
+                content: 'Article';
+                color: var(--mdc-theme-text-secondary-on-background);
+                display: inline-block;
+                font-size: var(--mdc-typography-caption-font-size);
+                position: absolute;
+                top: 8px;
+                text-decoration: none;
+            }
+            &::after {
+                content: 'launch';
+                font-family: var(--mdc-icon-font, "Material Icons");
+                position: absolute;
+                top: 23px;
+                right: 16px;
             }
         }
 

--- a/lib/components/styles/theme/_all-theme.scss
+++ b/lib/components/styles/theme/_all-theme.scss
@@ -170,8 +170,9 @@
 
   // Links
   a[href] {
-    color: var(--mdc-theme-text-primary-on-background);
+    color: var(--mdc-theme-secondary);
+    text-decoration: underline;
 
-    &:hover { text-decoration: underline; }
+    &:hover { text-decoration: none; }
   }
 }

--- a/stories/Introduction.stories.mdx
+++ b/stories/Introduction.stories.mdx
@@ -12,6 +12,12 @@ import { Meta, DocsContainer } from '@storybook/addon-docs';
     }}
 />
 
+<style>{`
+  .link-list {
+    margin-top: 4rem;
+  }
+`}</style>
+
 # Covalent Design System
 
 We're merging the Teradata Design System and Covalent into a single 

--- a/stories/guide-representing-state.stories.mdx
+++ b/stories/guide-representing-state.stories.mdx
@@ -1,4 +1,4 @@
-<!-- guide-representing-state.stories.mdx -->
+<!-- representing-state.stories.mdx -->
 
 import { Canvas, Meta, DocsContainer, Story } from '@storybook/addon-docs';
 
@@ -25,11 +25,11 @@ import { Canvas, Meta, DocsContainer, Story } from '@storybook/addon-docs';
   .status_lockup {
     display: flex;
   }
-  .status_lockup mwc-icon {
+  .status_lockup td-icon {
     margin-right: 8px;
   }
 
-  .docs-story mwc-list {
+  .docs-story td-list {
     margin: 0 auto;
     max-width: 30rem;
   }
@@ -115,17 +115,17 @@ Try to put the status column last (or nearly last).
     <tr class="mdc-data-table__row" data-row-id="u0">
       <td class="mdc-data-table__cell" id="r0">Title</td>
       <td class="mdc-data-table__cell mdc-data-table__cell">Lorem ipsum dolor sit amet, consecte...</td>
-      <td class="mdc-data-table__cell mdc-data-table__cell state_positive"><div class="status_lockup"><td-icon class="positive">check</td-icon> Successful</div></td>
+      <td class="mdc-data-table__cell mdc-data-table__cell state_positive"><div class="status_lockup positive"><td-icon class="positive">check</td-icon> Successful</div></td>
     </tr>
     <tr class="mdc-data-table__row" data-row-id="u1">
       <td class="mdc-data-table__cell" id="r1">Title</td>
       <td class="mdc-data-table__cell mdc-data-table__cell">Lorem ipsum dolor sit amet, consecte...</td>
-      <td class="mdc-data-table__cell mdc-data-table__cell state_caution"><div class="status_lockup"><td-icon class="caution">warning</td-icon> Some things didn't work</div></td>
+      <td class="mdc-data-table__cell mdc-data-table__cell state_caution"><div class="status_lockup caution"><td-icon class="caution">warning</td-icon> Some things didn't work</div></td>
     </tr>
     <tr class="mdc-data-table__row" data-row-id="u1">
       <td class="mdc-data-table__cell" id="r1">Title</td>
       <td class="mdc-data-table__cell mdc-data-table__cell">Lorem ipsum dolor sit amet, consecte...</td>
-      <td class="mdc-data-table__cell mdc-data-table__cell state_negative"><div class="status_lockup"><td-icon class="negative">error</td-icon> Failed</div></td>
+      <td class="mdc-data-table__cell mdc-data-table__cell state_negative"><div class="status_lockup negative"><td-icon class="negative">error</td-icon> Failed</div></td>
     </tr>
   </tbody>
 </table>
@@ -147,17 +147,17 @@ This is often too heavy-handed. Be careful.
     <tr class="mdc-data-table__row highlight_positive" data-row-id="u0">
       <td class="mdc-data-table__cell" id="r0">Title</td>
       <td class="mdc-data-table__cell mdc-data-table__cell">Lorem ipsum dolor sit amet, consecte...</td>
-      <td class="mdc-data-table__cell mdc-data-table__cell state_positive"><div class="status_lockup"><td-icon class="positive">check</td-icon> Successful</div></td>
+      <td class="mdc-data-table__cell mdc-data-table__cell state_positive"><div class="status_lockup positive"><td-icon class="positive">check</td-icon> Successful</div></td>
     </tr>
     <tr class="mdc-data-table__row highlight_caution" data-row-id="u1">
       <td class="mdc-data-table__cell" id="r1">Title</td>
       <td class="mdc-data-table__cell mdc-data-table__cell">Lorem ipsum dolor sit amet, consecte...</td>
-      <td class="mdc-data-table__cell mdc-data-table__cell state_caution"><div class="status_lockup"><td-icon class="caution">warning</td-icon> Some things didn't work</div></td>
+      <td class="mdc-data-table__cell mdc-data-table__cell state_caution"><div class="status_lockup caution"><td-icon class="caution">warning</td-icon> Some things didn't work</div></td>
     </tr>
     <tr class="mdc-data-table__row highlight_negative" data-row-id="u1">
       <td class="mdc-data-table__cell" id="r1">Title</td>
       <td class="mdc-data-table__cell mdc-data-table__cell">Lorem ipsum dolor sit amet, consecte...</td>
-      <td class="mdc-data-table__cell mdc-data-table__cell state_negative"><div class="status_lockup"><td-icon class="negative">error</td-icon> Failed</div></td>
+      <td class="mdc-data-table__cell mdc-data-table__cell state_negative"><div class="status_lockup negative"><td-icon class="negative">error</td-icon> Failed</div></td>
     </tr>
   </tbody>
 </table>

--- a/stories/writing-and-naming.stories.mdx
+++ b/stories/writing-and-naming.stories.mdx
@@ -1,0 +1,156 @@
+<!-- writing-and-naming.stories.mdx -->
+
+import { Canvas, Meta, DocsContainer, Story } from '@storybook/addon-docs';
+
+<Meta 
+    title="Guides/Writing and naming" 
+    parameters= {{
+        layout: 'fullscreen',
+        previewTabs: { 
+          canvas: { hidden: true } 
+        }
+    }}
+/>
+
+<style>{`
+  .caution {
+    color: var(--mdc-theme-caution);
+  }
+  .positive {
+    color: var(--mdc-theme-positive);
+  }
+  .negative {
+    color: var(--mdc-theme-negative);
+  }
+  .status_lockup {
+    display: flex;
+  }
+  .status_lockup td-icon {
+    margin-right: 8px;
+  }
+  #button-incorrect {
+    --mdc-typography-button-text-transform: none;
+  }
+`}</style>
+
+# Writing and naming
+
+## Capitalization
+
+We do not use title case. Page titles, actions, modal titles, etc should use sentence case. Sentence case capitalizes the first letter of the first word.
+
+###### See also
+
+<div className="link-list">
+  <a
+      className="link-item link-article"
+      href="https://medium.com/@jsaito/making-a-case-for-letter-case-19d09f653c98"
+      target="_blank"
+    >
+      Making a case for letter case
+  </a>
+</div>
+
+#### Page titles, section titles & labels
+
+Use sentence case for these and any items not explicitly mentioned in this doc.
+
+| <div class="status_lockup positive"><td-icon class="positive">check</td-icon> Correct</div> | <div class="status_lockup negative"><td-icon class="negative">error</td-icon> Incorrect</div> |
+| ------- | ----------- |
+| Are you sure you want to delete this item? | Are You Sure You Want to Delete This Item? |
+| Page title | Page Title |
+| Edit user John Doe | Edit User John Doe | 
+| Host name | Host Name |
+
+#### Buttons
+
+Buttons use all caps. This is a specific design exception that breaks the above rule.
+
+| <div class="status_lockup positive"><td-icon class="positive">check</td-icon> Correct</div> | <div class="status_lockup negative"><td-icon class="negative">error</td-icon> Incorrect</div> |
+| ------- | ----------- |
+| <td-button id="button-correct" outlined label="Button action"></td-button> | <td-button id="button-incorrect" outlined label="Button action"></td-button> |
+
+#### Email and web addresses
+
+When writing out an email address or website URL, use all lowercase.
+
+| <div class="status_lockup positive"><td-icon class="positive">check</td-icon> Correct</div> | <div class="status_lockup negative"><td-icon class="negative">error</td-icon> Incorrect</div> |
+| ------- | ----------- |
+| john.doe&#64;teradata.com | John.Doe&#64;Teradata.Com | // Have to use the html character code for the @ symbol so markdown doesn't automatically make this into a link
+| teradata.com | Teradata.Com |
+
+#### Which capitalization to use
+
+| Context | Case to use |
+| ------- | ----------- |
+| Page title | Sentence case |
+| Section title | Sentence case |
+| Body content | Sentence case |
+| Button | All caps |
+| Email address | Lowercase |
+| Web address / URL | Lowercase |
+
+***
+
+## Write UI copy as if you're having a conversation
+
+#### Interface communicating to the User
+
+Most items on a page are going to be the interface communicating something to the user. Write them as though the interface is talking to the user.
+
+| <div class="status_lockup positive"><td-icon class="positive">check</td-icon> Correct</div> | <div class="status_lockup negative"><td-icon class="negative">error</td-icon> Incorrect</div> |
+| ------- | ----------- |
+| Your bookmarks | My bookmarks |
+
+#### User communicating to the interface
+
+Commands such as buttons, menu items, etc. are the user giving the interface an order. Write them in first person:
+
+| <div class="status_lockup positive"><td-icon class="positive">check</td-icon> Correct</div> | <div class="status_lockup negative"><td-icon class="negative">error</td-icon> Incorrect</div> |
+| ------- | ----------- |
+| Show all my bookmarks | Show all your bookmarks |
+
+***
+
+## Active voice
+
+Use active voice. Avoid passive voice.
+
+In active voice, the subject of the sentence does the action. In passive voice, the subject of the sentence has the action done to it.
+
+Words like "was" and "by" may indicate that you're writing in passive voice. Scan for these words and rework sentences where they appear.
+
+###### See also
+<div className="link-list">
+  <a
+      className="link-item link-article"
+      href="https://medium.com/@jsaito/making-a-case-for-letter-case-19d09f653c98"
+      target="_blank"
+    >
+      Making a case for letter case
+  </a>
+</div>
+
+#### Exception
+
+Sometimes you want to specifically emphasize the action over the subject. In some cases, this is fine:
+
+| <div class="status_lockup caution"><td-icon class="caution">warning</td-icon> Be careful</div> |
+| ------- | ----------- |
+| Your account was flagged by our abuse team |
+
+***
+
+## Words to Avoid
+
+Some phrases carry connotations that we want to avoid. Make sure to use one of these recommended alternatives.
+
+| Don't use | Use instead |
+| --------- | ----------- |
+| Abort | Cancel, stop |
+| Blacklist | Blocklist |
+| Execute | Start (to begin or initialize), Run (to perform a function or to operate) |
+| Execution | Operation |
+| Master | Primary, active, main, parent (to show a hierarchical relationship) |
+| Slave | Secondary, standby, worker, child (to show a hierarchical relationship) |
+| Whitelist | Allowlist |


### PR DESCRIPTION
Add documentation for ux copywriting. Change default A display to use accent color with an underline.